### PR TITLE
Add support for Laravel ^9.0, drop for <9.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: "ubuntu-20.04"
     strategy:
       matrix:
-        php: ["7.4", "8.0", "8.1"]
+        php: ["8.0", "8.1"]
         stability: ["prefer-stable", "prefer-lowest"]
     name: PHP ${{ matrix.php }}, ${{ matrix.stability }}
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "illuminate/collections": "^8.0"
+        "illuminate/collections": "^9.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/src/TypedCollection.php
+++ b/src/TypedCollection.php
@@ -31,7 +31,7 @@ class TypedCollection extends Collection
     }
 
 
-    public function offsetSet($key, $value)
+    public function offsetSet($key, $value): void
     {
         $this->assertValidType($value);
 


### PR DESCRIPTION
Hello there,

With the release of Laravel 9 on Feb 8th, i'm trying to update my projects to it. However i encountered this package which does not support Laravel 9 yet so thought i'd help out.

Let me know if i've missed anything, i've;
- updated the composer.json
- made the tests pass
- Added `void` return type to offsetSet as Laravel specifies this now
  
Thanks for your time