### PR TITLE
ADD: Template typing to Collection and LazyCollection.

### DIFF
--- a/src/ChecksForValidTypes.php
+++ b/src/ChecksForValidTypes.php
@@ -6,7 +6,7 @@ use InvalidArgumentException;
 
 trait ChecksForValidTypes
 {
-    /** @var array<class-string>  */
+    /** @var array<int, class-string>  */
     protected static $allowedTypes = [];
 
     /**

--- a/src/LazyTypedCollection.php
+++ b/src/LazyTypedCollection.php
@@ -4,10 +4,23 @@ namespace Gamez\Illuminate\Support;
 
 use Illuminate\Support\LazyCollection;
 
+/**
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @extends LazyCollection<TKey, TValue>
+ */
 class LazyTypedCollection extends LazyCollection
 {
     use ChecksForValidTypes;
 
+    /**
+     * Create a new lazy collection instance.
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|(Closure(): \Generator<TKey, TValue, mixed, void>)|self<TKey, TValue>|array<TKey, TValue>|null  $source
+     *
+     * @return void
+     */
     public function __construct($source = null)
     {
         parent::__construct($source);
@@ -27,6 +40,9 @@ class LazyTypedCollection extends LazyCollection
         return $this->untype()->pluck($value, $key);
     }
 
+    /**
+     * @return array<TKey, mixed>
+     */
     public function toArray(): array
     {
         // If the items in the collection are arrayable themselves,
@@ -38,6 +54,8 @@ class LazyTypedCollection extends LazyCollection
 
     /**
      * Returns an untyped collection with all items
+     *
+     * @return LazyCollection<TKey, TValue>
      */
     public function untype(): LazyCollection
     {

--- a/src/TypedCollection.php
+++ b/src/TypedCollection.php
@@ -4,10 +4,19 @@ namespace Gamez\Illuminate\Support;
 
 use Illuminate\Support\Collection;
 
+/**
+ * @template TKey of array-key
+ * @template TValue
+ *
+ * @extends Collection<TKey, TValue>
+ */
 class TypedCollection extends Collection
 {
     use ChecksForValidTypes;
 
+    /**
+     * @param \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue> $items
+     */
     public function __construct($items = [])
     {
         $this->assertValidTypes(...$items);
@@ -18,7 +27,8 @@ class TypedCollection extends Collection
     /**
      * Push one or more items onto the end of the collection.
      *
-     * @param  mixed  $values [optional]
+     * @param TValue ...$values
+     *
      * @return $this
      */
     public function push(...$values)
@@ -30,7 +40,10 @@ class TypedCollection extends Collection
         return parent::push(...$values);
     }
 
-
+    /**
+     * @param TKey $key
+     * @param TValue $value
+     */
     public function offsetSet($key, $value): void
     {
         $this->assertValidType($value);
@@ -38,6 +51,10 @@ class TypedCollection extends Collection
         parent::offsetSet($key, $value);
     }
 
+    /**
+     * @param TValue $value
+     * @param ?TKey $key
+     */
     public function prepend($value, $key = null)
     {
         $this->assertValidType($value);
@@ -45,6 +62,9 @@ class TypedCollection extends Collection
         return parent::prepend($value, $key);
     }
 
+    /**
+     * @param TValue $value
+     */
     public function add($value)
     {
         $this->assertValidType($value);
@@ -62,11 +82,17 @@ class TypedCollection extends Collection
         return $this->untype()->pluck($value, $key);
     }
 
+    /**
+     * @return Collection<int, TKey>
+     */
     public function keys()
     {
         return $this->untype()->keys();
     }
 
+    /**
+     * @return array<TKey, mixed>
+     */
     public function toArray(): array
     {
         // If the items in the collection are arrayable themselves,
@@ -78,6 +104,8 @@ class TypedCollection extends Collection
 
     /**
      * Returns an untyped collection with all items
+     *
+     * @return Collection<TKey, TValue>
      */
     public function untype(): Collection
     {


### PR DESCRIPTION
Laravel 9 added @template tags to it's collections which help tools such as `phpstan` analyze and understand laravel codebases.

When i upgraded it to 9, i missed these off 'cos i didn't know they were there, so now i've added them :) 

this allows us to do:

```
/**
 * @extends TypedCollection<int, ClassOne|ClassTwo>
 */
class MyCollection extends TypedCollection
{
  protected static $allowedTypes = [ClassOne::class, ClassTwo::class];
}
```

and phpstan / psalm etc will understand the types yielded from the collection