### PR TITLE
feat: Add typedCollect helper function and related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added support for Laravel 11 ([#21](https://github.com/jeromegamez/typed-collection/issues/21))
 - Dropped support for Laravel 9
+- Added a new `typedCollect()` helper method, based off the `collect()` helper method that comes with the Laravel framework.
+  ([#20](https://github.com/jeromegamez/typed-collection/issues/20))
 
 ## 6.1.0 - 2023-02-17
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,15 @@ Output: A People collection only accepts objects of the following type(s): Perso
 */
 ```
 
+### Helper functions
+
+The `typedCollect()` helper function enables you to dynamically create typed collections
+on the fly:
+
+```php
+$dateTimes = typedCollect([new DateTime(), new DateTime()], DateTimeInterface::class);
+```
+
 For further information on how to use Laravel Collections,
 have a look at the [official documentation].
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,10 @@
     "autoload": {
         "psr-4": {
             "Gamez\\Illuminate\\Support\\": "src"
-        }
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -9,17 +9,15 @@ if (!function_exists('typedCollect')) {
      * @template TKey of array-key
      * @template TValue
      *
-     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
-     * @param string|array $type
+     * @param \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null $value
+     * @param string|string[] $types
      * @return \Illuminate\Support\Collection<TKey, TValue>
      */
     function typedCollect($value = [], string|array $types = [])
     {
         $types = is_array($types) ? $types : [$types];
 
-        $collection = new class extends TypedCollection
-        {
-        };
+        $collection = new class extends TypedCollection {};
 
         $reflectionClass = new ReflectionClass($collection);
         $reflectionProperty = $reflectionClass->getProperty('allowedTypes');

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,30 @@
+<?php
+
+use Gamez\Illuminate\Support\TypedCollection;
+
+if (!function_exists('typedCollect')) {
+    /**
+     * Create an anonymous typed collection
+     *
+     * @template TKey of array-key
+     * @template TValue
+     *
+     * @param  \Illuminate\Contracts\Support\Arrayable<TKey, TValue>|iterable<TKey, TValue>|null  $value
+     * @param string|array $type
+     * @return \Illuminate\Support\Collection<TKey, TValue>
+     */
+    function typedCollect($value = [], string|array $types = [])
+    {
+        $types = is_array($types) ? $types : [$types];
+
+        $collection = new class extends TypedCollection
+        {
+        };
+
+        $reflectionClass = new ReflectionClass($collection);
+        $reflectionProperty = $reflectionClass->getProperty('allowedTypes');
+        $reflectionProperty->setValue($collection, $types);
+
+        return $collection::make($value);
+    }
+}

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Gamez\Illuminate\Support\Tests;
+
+use DateTime;
+use DateTimeInterface;
+use Gamez\Illuminate\Support\Tests\ArrayableItem;
+use Gamez\Illuminate\Support\TypedCollection;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+class HelpersTest extends TestCase
+{
+    /** @test */
+    public function it_cannot_be_created_with_an_unsupported_type_of_item()
+    {
+        $this->expectException(InvalidArgumentException::class);
+        typedCollect([new DateTime(), 'string', new DateTime()], DateTimeInterface::class);
+    }
+
+    /** @test */
+    public function it_can_be_created_with_supported_types()
+    {
+        $typedCollection = typedCollect([new DateTime(), new DateTime()], DateTimeInterface::class);
+        $this->assertInstanceOf(TypedCollection::class, $typedCollection);
+        $this->addToAssertionCount(1);
+    }
+
+    /** @test */
+    public function it_can_accept_an_array_of_types()
+    {
+        $typedCollection = typedCollect([new DateTime(), new ArrayableItem()], [DateTimeInterface::class, ArrayableItem::class]);
+        $this->assertInstanceOf(TypedCollection::class, $typedCollection);
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
This PR adds a new `typedCollect()` helper method, based off the `collect()` helper method https://laravel.com/docs/11.x/collections#method-collect that comes with the Laravel framework.

This will allow developers to dynamically create typed collections on the fly.

```php
typedCollect([new DateTime(), new DateTime()], DateTimeInterface::class);
```